### PR TITLE
fix: remove inappropriate smoke tests from workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,27 +122,6 @@ jobs:
         run: make test
         working-directory: think
       
-      - name: Install Spin
-        uses: fermyon/actions/spin/setup@v1
-        with:
-          version: v3.3.1
-      
-      - name: Smoke test release build
-        run: |
-          # Quick validation that the release build works
-          spin up --listen 127.0.0.1:3000 &
-          SPIN_PID=$!
-          
-          sleep 30
-          
-          if curl -s http://127.0.0.1:3000/mcp >/dev/null 2>&1; then
-            echo "✅ Release build validated"
-          else
-            echo "❌ Release build failed smoke test"
-            exit 1
-          fi
-          
-          kill $SPIN_PID || true
 
   # ===== PUBLISH TO GHCR =====
   publish-ghcr:


### PR DESCRIPTION
## Summary

Removes inappropriate Spin-based smoke tests from both CI and release workflows.

## Problem

The workflows were trying to run  and test against an MCP endpoint, but:
- FTL tools don't have  files (they use )
- Integration testing would require the FTL CLI, not Spin
- The smoke tests were failing with "Default file 'spin.toml' not found"

## Changes

- **Release Workflow**: Removed Install Spin step and smoke test job
- **CI Workflow**: Was already clean (no smoke tests)

## Testing

Both workflows now focus on appropriate testing:
- **CI**: Format checking, linting, WASM build verification, unit tests  
- **Release**: Unit tests, artifact validation, GHCR publishing, cosign signing

🤖 Generated with [Claude Code](https://claude.ai/code)